### PR TITLE
Buff the regular shotgun

### DIFF
--- a/decorate/WeaponsAmmo.dec
+++ b/decorate/WeaponsAmmo.dec
@@ -4193,31 +4193,48 @@ Actor Shotgun2 : MarineWeapon
 			goto FireActual
 		Fire1End:
 			SHTG A 7 A_GunFlash("Flash")
+			TNT1 A 0 A_JumpIf(CallACS("MiscVarCheckDECORATE",10021) >= 3, "Fire1EndAuto")
 			SHTG BC 5
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(4); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(3); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(4); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(3); }
 			}
 			SHTG D 4
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(3); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(2); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(3); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(2); }
 			}
 			SHTG CB 5
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(4); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(3); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(4); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(3); }
 			}
 			SHTG A 3
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 3) { A_SetTics(2); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(2); }
 			}
 			SHTG A 7
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(6); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(5); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(6); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(5); }
 			 A_ReFire;
 			}
+			Goto Ready
+		Fire1EndAuto:
+			SHTG B 8 A_SetTics(
+				/* The formula here is:
+				 *   let d = duration of this frame
+				 *   let p = perk level (up to 5)
+				 *   d = 8 + (4 * (3 - p))
+				 *
+				 * Hence, the durations of this frame will be:
+				 *   p  d
+				 *   3  8
+				 *   4  4
+				 *   5  0
+				 */
+				8 + (4 * (3 - min(CallACS("MiscVarCheckDECORATE",10021), 5)))
+			)
 			Goto Ready
 		Fire2:
 			SHTG I 3
@@ -4227,31 +4244,48 @@ Actor Shotgun2 : MarineWeapon
 			goto FireActual
 		Fire2End:
 			SHTG I 7 A_GunFlash("Flash2")
+			TNT1 A 0 A_JumpIf(CallACS("MiscVarCheckDECORATE",10021) >= 3, "Fire2EndAuto")
 			SHTG JK 5
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(4); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(3); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(4); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(3); }
 			}
 			SHTG L 4
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(3); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(2); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(3); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(2); }
 			}
 			SHTG KJ 5
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(4); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(3); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(4); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(3); }
 			}
 			SHTG I 3
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 3) { A_SetTics(2); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(2); }
 			}
 			SHTG I 7
 			{
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(6); }
-			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 4) { A_SetTics(5); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 1) { A_SetTics(6); }
+			 if (ACS_NamedExecuteWithResult("MiscVarCheckDECORATE",10021) >= 2) { A_SetTics(5); }
 			 A_ReFire;
 			}
+			Goto Ready
+		Fire2EndAuto:
+			SHTG J 8 A_SetTics(
+				/* The formula here is:
+				 *   let d = duration of this frame
+				 *   let p = perk level (up to 5)
+				 *   d = 8 + (4 * (3 - p))
+				 *
+				 * Hence, the durations of this frame will be:
+				 *   p  d
+				 *   3  8
+				 *   4  4
+				 *   5  0
+				 */
+				8 + (4 * (3 - min(CallACS("MiscVarCheckDECORATE",10021), 5)))
+			)
 			Goto Ready
 	}
 }


### PR DESCRIPTION
The regular shotgun becomes pretty much useless as soon as the super shotgun is obtained. This PR fixes that by making the regular shotgun gain much more firing speed from the pellet accuracy perk, and become full-auto at perk level 5.