### PR TITLE
Fix kill % being unable to reach 100% when some advanced monsters become eligible to spawn.

### DIFF
--- a/zscript/dvds-monsterspawners.zc
+++ b/zscript/dvds-monsterspawners.zc
@@ -27,6 +27,7 @@ class AetheriusMonsterSpawner : RandomSpawner abstract
 		else 
 		{
 			let result = actor.TestMobjLocation();
+			actor.ClearCounters();
 			actor.Destroy();
 			return result;
 		}


### PR DESCRIPTION
The issue was that `AetheriusMonsterSpawner` would sometimes test-spawn a monster, check if it fits, and immediately delete it. Spawning, however, has the side effect of increasing the total possible kills on the map! Fortunately, the engine provides the `Actor::ClearCounters` method to undo that side effect.

I wish all bugs were this easy to fix!