### PR TITLE
Fix a typo that made the Plasma Repeater extremely overpowered.

### DIFF
--- a/zscript/dvds-projectiles.zc
+++ b/zscript/dvds-projectiles.zc
@@ -186,7 +186,7 @@ class AetheriusBaseProjectileZSC : AetheriusBaseZSC
 		{
 			damage = 7 + (PlasmaAccuracyPerkLevel * 4) + (PlasmaAccuracyEXPerkLevel * 10); // 7
 			extradmg1 = PlayerAGL * 0.40; // 40% of Agility
-			extradmg2 = PlayerSTR * 14.28282829; // 14.28~% of Strength 
+			extradmg2 = PlayerSTR * 0.1428282829; // 14.28~% of Strength 
 		}
 
 		if (type == 11) // Plasma

--- a/zscript/dvds-weapclass.zc
+++ b/zscript/dvds-weapclass.zc
@@ -203,7 +203,7 @@ class AetheriusBaseWeaponZSC : Weapon
 		{
 			damage = 7 + (PlasmaAccuracyPerkLevel * 4) + (PlasmaAccuracyEXPerkLevel * 10); // 7
 			extradmg1 = PlayerAGL * 0.40; // 40% of Agility
-			extradmg2 = PlayerSTR * 14.28282829; // 14.28~% of Strength 
+			extradmg2 = PlayerSTR * 0.1428282829; // 14.28~% of Strength 
 		}
 
 		if (type == 11) // Plasma


### PR DESCRIPTION
I *thought* the Plasma Repeater seemed a bit overpowered. Turns out I was right: there's a typo in its damage calculation. Instead of adding 14.28% of the user's strength as damage (like the comment says), it was adding 1428% of the user's strength!