### PR TITLE
Port over the AetheriusMonsterSpawner classes to use the new RandomSpawner.ChooseSpawn method in GZDoom 3.5

### DIFF
--- a/zscript.zc
+++ b/zscript.zc
@@ -1,4 +1,4 @@
-version "3.3"
+version "3.5"
 
 #include "zscript/dvds-eventhandlers.zc"
 #include "zscript/dvds-weapclass.zc"

--- a/zscript/dvds-monsterspawners.zc
+++ b/zscript/dvds-monsterspawners.zc
@@ -16,8 +16,6 @@ class BaseMonsterSpawner : Actor
 // BASE Spawner
 class AetheriusMonsterSpawner : RandomSpawner abstract
 {
-	virtual Class<Actor> ChooseWhatToSpawn() { return null; }
-	
 	protected bool CanFitHere(Class<Actor> actorClass) 
 	{
 		let actor = Spawn(actorClass, Pos, NO_REPLACE);
@@ -32,34 +30,6 @@ class AetheriusMonsterSpawner : RandomSpawner abstract
 			return result;
 		}
 	}
-
-	override void BeginPlay()
-	{
-		Actor.BeginPlay();
-		
-		let wts = ChooseWhatToSpawn();
-		
-		if (!wts)
-		{
-			Spawn("Unknown", Pos, NO_REPLACE);
-			Console.Printf(TEXTCOLOR_RED.."%s.ChooseWhatToSpawn returned null. Did you forget to override that method?", GetClassName());
-			Destroy();
-			return;
-		}
-		
-		{
-			let replacement = GetReplacement(wts);
-			if (replacement)
-				wts = replacement;
-		}
-		
-		Species = Name(wts);
-		let def = GetDefaultByType(wts);
-		Speed = def.Speed;
-		bMissile |= def.bMissile;
-		bSeekerMissile |= def.bSeekerMissile;
-		bSpectral |= def.bSpectral;
-	}
 }
 
 // Doom Monsters
@@ -71,7 +41,7 @@ class ZombiemanSpawner : AetheriusMonsterSpawner replaces Zombieman
 		Radius 20;
 		Height 56;
 	}
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -126,7 +96,7 @@ class ShotgunGuySpawner : AetheriusMonsterSpawner replaces ShotgunGuy
 		Radius 20;
 		Height 56;
 	}
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -162,7 +132,7 @@ class ChaingunGuySpawner : AetheriusMonsterSpawner replaces ChaingunGuy
 		Radius 20;
 		Height 56;
 	}
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -197,7 +167,7 @@ class DoomImpSpawner : AetheriusMonsterSpawner replaces DoomImp
 		Radius 20;
 		Height 56;
 	}
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -248,7 +218,7 @@ class DemonSpawner : AetheriusMonsterSpawner replaces Demon
 		Height 56;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -295,7 +265,7 @@ class SpectreSpawner : AetheriusMonsterSpawner replaces Spectre
 		Height 56;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -331,7 +301,7 @@ class RevenantSpawner : AetheriusMonsterSpawner replaces Revenant
 		Radius 20;
 		Height 56;
 	}
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -360,7 +330,7 @@ class CacodemonSpawner : AetheriusMonsterSpawner replaces Cacodemon
 		Radius 31;
 		Height 56;
 	}
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -449,7 +419,7 @@ class PainElementalSpawner : AetheriusMonsterSpawner replaces PainElemental
 		Height 56;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -488,7 +458,7 @@ class LostSoulSpawner : AetheriusMonsterSpawner replaces LostSoul
 		Height 56;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -515,7 +485,7 @@ class ArachnotronSpawner : AetheriusMonsterSpawner replaces Arachnotron
 		Height 64;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -550,7 +520,7 @@ class HellKnightSpawner : AetheriusMonsterSpawner replaces HellKnight
 		Height 64;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -614,7 +584,7 @@ class MancubusSpawner : AetheriusMonsterSpawner replaces Fatso
 		Height 64;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -647,7 +617,7 @@ class ArchvileSpawner : AetheriusMonsterSpawner replaces Archvile
 		Height 56;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -676,7 +646,7 @@ class BaronofHellSpawner : AetheriusMonsterSpawner replaces BaronofHell
 		Height 64;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -742,7 +712,7 @@ class SpiderMastermindSpawner : AetheriusMonsterSpawner replaces SpiderMastermin
 		Height 100;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -767,7 +737,7 @@ class CyberdemonSpawner : AetheriusMonsterSpawner replaces Cyberdemon
 		Height 110;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");
@@ -792,7 +762,7 @@ class FlyingBalrogSpawner : AetheriusMonsterSpawner // 21122
 		Height 64;
 	}
 
-	override Class<Actor> ChooseWhatToSpawn()
+	override Name ChooseSpawn()
 	{
 		int modtype = CallACS("CheckModType");
 		int doomtype = CallACS("CheckDoomType");


### PR DESCRIPTION
Remember that ugly hack I wrote to make `AetheriusMonsterSpawner` work like you wanted? GZDoom 3.5's `RandomSpawner` has the functionality built-in! This PR updates `AetheriusMonsterSpawner` to use it (and bumps the ZScript version to 3.5).